### PR TITLE
Include application name in jobs

### DIFF
--- a/src/components/JobHeader.vue
+++ b/src/components/JobHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    {{ job.name }} {{ job.source }} {{ job.entity }}
+    {{ job.name }} {{ job.application || job.source }} {{ job.entity }}
     <b-badge
       v-for="level in job.levels"
       :key="level.level"

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -62,6 +62,7 @@ export async function queryJobs(filter = {}) {
       day,
       name,
       source,
+      application,
       catalogue,
       entity,
       starttime,


### PR DESCRIPTION
Jobs are identified by a functional name (source) and an application
name (application).

The name of the application is shown in the job header
If missing, the source name is used