### PR TITLE
Fix "end of workflow" in logging brk prepare

### DIFF
--- a/src/config/jobs.js
+++ b/src/config/jobs.js
@@ -79,4 +79,3 @@ export const allJobs = [
   "RELATE nap nap",
   "RELATE wkpb wkpb"
 ];
-

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -178,8 +178,8 @@ export async function queryLogsForJobStep(jobid, stepid) {
   return _queryLogs(select);
 }
 
-export async function queryLogsForJob(process_id) {
-  const select = `(processId: "${process_id}")`;
+export async function queryLogsForJob(jobid) {
+  const select = `(jobid: ${jobid})`;
   return _queryLogs(select);
 }
 

--- a/src/services/gob.js
+++ b/src/services/gob.js
@@ -61,8 +61,8 @@ export async function logs(source, catalogue, entity) {
   return _logs(data);
 }
 
-export async function logsForJob(process_id) {
-  var data = await queryLogsForJob(process_id);
+export async function logsForJob(jobid) {
+  var data = await queryLogsForJob(jobid);
   return _logs(data);
 }
 

--- a/src/views/Jobs.vue
+++ b/src/views/Jobs.vue
@@ -59,7 +59,7 @@
           <div v-for="job in filteredJobs" :key="job.jobid" class="mb-2">
             <div>
               <b-btn
-                v-b-toggle="job.processId"
+                v-b-toggle="job.jobid.toString()"
                 @click="loadLogs(job)"
                 block
                 variant="outline-secondary"
@@ -68,7 +68,7 @@
               </b-btn>
 
               <b-collapse
-                :id="job.processId"
+                :id="job.jobid.toString()"
                 accordion="job-accordion"
                 class="mt-2"
               >
@@ -273,7 +273,7 @@ export default {
       let n = 0;
       let logs = [];
       while (n < 10 && !logs.length) {
-        logs = await logsForJob(job.processId);
+        logs = await logsForJob(job.jobid);
         n += 1;
       }
       job.logs = logs;


### PR DESCRIPTION
Access log messages on jobid instead of processid.

This also solves the problem that the overview and detail view
did not always match