### PR TITLE
Allow relates to be started without a collection

### DIFF
--- a/src/components/JobStart.vue
+++ b/src/components/JobStart.vue
@@ -11,7 +11,11 @@
 </template>
 
 <script>
-import { createJob, catalogOnlyJobs } from "../services/gob";
+import {
+  createJob,
+  catalogOnlyJobs,
+  collectionOptionalJobs
+} from "../services/gob";
 
 export default {
   name: "JobStart",
@@ -30,7 +34,8 @@ export default {
     canStart() {
       return (
         !this.result &&
-        (catalogOnlyJobs.includes(this.action) ||
+        (catalogOnlyJobs.includes(this.action.toLowerCase()) ||
+          collectionOptionalJobs.includes(this.action.toLowerCase()) ||
           (this.catalog && this.collection))
       );
     },

--- a/src/services/gob.js
+++ b/src/services/gob.js
@@ -12,7 +12,8 @@ import {
   queryLogsForJobStep
 } from "../graphql/queries";
 
-export const catalogOnlyJobs = ["Prepare", "Export Test"];
+export const catalogOnlyJobs = ["prepare", "export test"];
+export const collectionOptionalJobs = ["relate"];
 
 export async function sources() {
   var data = await querySourceEntities();
@@ -97,7 +98,7 @@ export async function createJob(action, catalogue, collection) {
 
   action = action.toLowerCase().replace(" ", "_");
   catalogue = catalogue.toLowerCase();
-  collection = (collection || "").toLowerCase();
+  collection = collection ? collection.toLowerCase() : null;
 
   const requestOptions = {
     method: "POST",

--- a/src/views/Management.vue
+++ b/src/views/Management.vue
@@ -81,7 +81,7 @@ export default {
       }));
     },
     onAction(catalog, action) {
-      if (catalogOnlyJobs.includes(action)) {
+      if (catalogOnlyJobs.includes(action.toLowerCase())) {
         delete this.collection[catalog];
         this.collectionDisabled[catalog] = true;
       } else {


### PR DESCRIPTION
This fix works together with the fix in gobupload to allow empty values in collection. The frontend is fixed to allow relates to be restarted from the detail page and allows both a catalog or a catalog collection relate job from the management page.