### PR TITLE
PGB 1778

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
     "serialize-javascript": "^3.1.0",
     "styled-components": "^5.1.1"
   },
+  "resolutions": {
+    "**/**/serialize-javascript": "^3.1.0",
+    "**/**/http-proxy": "^1.18.1"
+  },
   "scripts": {
     "start": "PORT=8080 react-scripts start",
     "build": "react-scripts build",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-redux": "^7.1.3",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1",
+    "serialize-javascript": "^3.1.0",
     "styled-components": "^5.1.1"
   },
   "scripts": {

--- a/src/components/dashboard/JobSummaries.js
+++ b/src/components/dashboard/JobSummaries.js
@@ -176,7 +176,7 @@ class JobSummaries extends React.Component {
             const [isStart, isEnd] = [[starttime, job.isoStarttime], [endtime, job.isoEndtime]]
                 .map(([t, jt]) => jt ? t.getTime() === new Date(jt).getTime() : true)
                 .map(b => b ? 'class="font-weight-bold"': '')
-            const duration = job.isoEndtime ? asDuration(job.isoStarttime, job.isoEndtime) : ''
+            const duration = asDuration(job.isoStarttime, job.isoEndtime || new Date())
             return `<tr class="text-nowrap">
                         <td>${job.description}</td>
                         <td ${isStart}>${start}</td>

--- a/src/services/gob.js
+++ b/src/services/gob.js
@@ -237,7 +237,7 @@ export async function getJobs(filter) {
       starttime,
       endtime
     );
-    job.jobId = `${job.name}.${job.source}.${job.application}.${job.catalogue}.${job.entity}.${job.attribute}`;
+    job.jobId = `${job.name}.${job.catalogue}.${job.entity}.${job.attribute}`;
     if (jobIds[job.jobId]) {
       job.execution = "voorgaande";
     } else if (["scheduled", "started"].includes(job.status)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5338,7 +5338,7 @@ http-proxy-middleware@0.19.1:
     micromatch "^3.1.10"
 
 http-proxy@^1.17.0:
-  version "1.18.1"
+  version "1.18.0"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.0.tgz#dbe55f63e75a347db7f3d99974f2692a314a6a3a"
   integrity sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==
   dependencies:
@@ -8800,7 +8800,7 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
+randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -9678,6 +9678,13 @@ serialize-javascript@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
   integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+
+serialize-javascript@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
+  integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
+  dependencies:
+    randombytes "^2.1.0"
 
 serve-index@^1.9.1:
   version "1.9.1"
@@ -11014,7 +11021,7 @@ websocket-driver@>=0.5.1:
     websocket-extensions ">=0.1.1"
 
 websocket-extensions@>=0.1.1:
-  version "0.1.4"
+  version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
   integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5337,10 +5337,10 @@ http-proxy-middleware@0.19.1:
     lodash "^4.17.11"
     micromatch "^3.1.10"
 
-http-proxy@^1.17.0:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.0.tgz#dbe55f63e75a347db7f3d99974f2692a314a6a3a"
-  integrity sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==
+http-proxy@^1.17.0, http-proxy@^1.18.1:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
+  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
   dependencies:
     eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"
@@ -9674,12 +9674,7 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
-  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
-
-serialize-javascript@^3.1.0:
+serialize-javascript@^2.1.2, serialize-javascript@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
   integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==


### PR DESCRIPTION
Remove source/application from jobId to show only the most recent execution of a job.

Fixed some security issues by upgrading library versions.

Found that the job duration was not correctly shown for running jobs. As this was a one-line to fix I've include this in the PR