### PR TITLE
PGB 1979

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,7 @@
       }
     }
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "mockdate": "^3.0.2"
+  }
 }

--- a/src/components/common/AppHeader.js
+++ b/src/components/common/AppHeader.js
@@ -62,6 +62,17 @@ function AppHeader() {
         }
     }
 
+    function statusIcons(key) {
+        // Optionally add statusIcons (indicators) to menu items
+        const indicators = {
+            Status: ["waiting", "processing", "locks"],
+            Jobs: ["jobs"]
+        }
+        if (indicators[key]) {
+            return <StatusIcons className="statusicons" indicators={indicators[key]}></StatusIcons>
+        }
+    }
+
     const navigation = (
         <MenuInline>
             {Object.entries(menuItems).map(([key, value]) => (
@@ -69,7 +80,7 @@ function AppHeader() {
                     <Link to={value} className={'menulink'}>
                         <MenuButton active={isActive(value)}>
                             {key}
-                            {key === 'Status' ? <StatusIcons className="statusicons"></StatusIcons> : ''}
+                            {statusIcons(key)}
                         </MenuButton>
                     </Link>
                 </MenuItem>

--- a/src/components/jobs/JobHeader.js
+++ b/src/components/jobs/JobHeader.js
@@ -5,38 +5,49 @@ import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import moment from 'moment';
 import {get_gob_api} from '../../services/api';
+import {faDownload} from "@fortawesome/free-solid-svg-icons";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+
+import './jobs.css'
 
 const JobHeader = props => {
     const {job} = props;
 
+    const badge = (level, link) => {
+        // default badge title is level and number of messages, example: infos 36
+        let title = <span>
+            {level} {job[level]}
+        </span>
+        let tooltip = null
+        if (link) {
+            // for data messages a link is available to download the messages, wrap the title in a hyperlink
+            title = <a className={"badgeLink"} href={link}>
+                {title} <FontAwesomeIcon icon={faDownload} />
+            </a>
+            tooltip = `Download QA messages`
+        }
+        // A click on a badge does not propagate and stops any other action
+        return <Badge key={level} title={tooltip} className={"mr-2 " + level} variant={"light"}
+                      onClick={e => e.stopPropagation()}>
+            {title}
+        </Badge>
+    }
+
     const badges = () => {
-        const levels = [
-            'infos',
-            'warnings',
-            'errors',
-            'datainfos',
-            'dataerrors'
-        ]
+        const dataLink = `${get_gob_api()}gob/dump/qa/${job.catalogue}_${job.entity}?format=csv`;
 
-        const badge = level =>
-            <Badge key={level} className={"mr-2 " + level} variant={"light"}>
-                {level} {job[level]}
-            </Badge>
-
-        const badges = levels
-            .filter(level => job[level] > 0)
-            .map(level => badge(level));
-
-        if (job['datawarnings'] > 0) {
-            // Add datawarnings badge with link to QA CSV for given catalogue/collection
-            const link = `${get_gob_api()}gob/dump/qa/${job.catalogue}_${job.entity}?format=csv`;
-            badges.push(
-                <a key={'datawarnings'} href={link} target={'_blank'} rel={'noopener noreferrer'}>
-                    {badge('datawarnings')}
-                </a>);
+        const levels = {
+            infos: {},
+            warnings: {},
+            errors: {},
+            datainfos: {link: dataLink},
+            datawarnings: {link: dataLink},
+            dataerrors: {link: dataLink}
         }
 
-        return badges;
+        return Object.entries(levels)
+            .filter(([level, data]) => job[level] > 0)
+            .map(([level, data]) => badge(level, data.link));
     }
 
     const attribute = () => {

--- a/src/components/jobs/jobs.css
+++ b/src/components/jobs/jobs.css
@@ -16,3 +16,12 @@
     height: 100%;
     overflow-y: scroll;
 }
+
+.badgeLink {
+    color: #212529
+}
+
+.badgeLink:hover {
+    color: #212529;
+    text-decoration: none;
+}

--- a/src/components/status/StatusIcons.js
+++ b/src/components/status/StatusIcons.js
@@ -1,6 +1,7 @@
 import React from "react";
-import {getQueues} from "./services/queues";
-import {getDbLocks} from "../../services/gob_api";
+import PropTypes from 'prop-types';
+import {getJobs, getQueues} from "./services/queues";
+import {getDbLocks} from "./services/database";
 
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome'
 import {faLock, faInbox, faCog} from '@fortawesome/free-solid-svg-icons'
@@ -10,12 +11,12 @@ class StatusIcons extends React.Component {
     state = {
         queues: [],
         locks: [],
-        queries: []
+        jobs: []
     }
 
     async componentDidMount() {
         await this.update();
-        this.interval = setInterval(this.update.bind(this), 2500);
+        this.interval = setInterval(this.update.bind(this), 500);
     }
 
     componentWillUnmount() {
@@ -24,27 +25,31 @@ class StatusIcons extends React.Component {
 
     async update() {
         // Load status data in parallel
-        const [queues, locks] = [getQueues(), getDbLocks()]
+        const [queues, locks, jobs] = [getQueues(), getDbLocks(), getJobs()]
         this.setState({
             queues: await queues,
-            locks: await locks});
+            locks: await locks,
+            jobs: await jobs
+        });
     }
 
     indicator(n, icon, className) {
         className = (className || '') + ' statusicon'
-        return <span>
-            <FontAwesomeIcon icon={icon} className={className} aria-hidden={"false"}/>{n}
-        </span>
+        icon = icon && <FontAwesomeIcon icon={icon} className={className} aria-hidden={"false"}/>
+        return <span>{icon}{n.toLocaleString()}</span>
     }
 
     render() {
         const indicators = {
             waiting: { icon: faInbox, n: this.state.queues.reduce((a, b) => a + b.messages_ready, 0) },
             processing: { icon: faCog, className: "fa-spin", n: this.state.queues.reduce((a, b) => a + b.messages_unacknowledged, 0)},
-            locks: { icon: faLock, n: this.state.locks.length}
+            locks: { icon: faLock, n: this.state.locks.length},
+            jobs: {  n: this.state.jobs }
         }
 
-        const activeIndictors = Object.entries(indicators).filter(([key, v]) => v.n > 0)
+        const activeIndictors = Object.entries(indicators)
+            .filter(([key, v]) => this.props.indicators.includes(key))
+            .filter(([key, v]) => v.n > 0)
 
         if (activeIndictors.length === 0) {
             return null;
@@ -58,6 +63,10 @@ class StatusIcons extends React.Component {
             </span>
         )
     }
+}
+
+StatusIcons.propTypes = {
+    indicators: PropTypes.arrayOf(PropTypes.string).isRequired  // Which indicators should be shown
 }
 
 export default StatusIcons;

--- a/src/components/status/index.js
+++ b/src/components/status/index.js
@@ -7,7 +7,7 @@ import StatusQueues from "./StatusQueues";
 import StatusServices from "./StatusServices";
 import {getServices} from "./services/services";
 import {getQueues} from "./services/queues";
-import {getDbLocks, getDbQueries} from "../../services/gob_api";
+import {getDbLocks, getDbQueries} from "./services/database";
 
 class StatusPage extends React.Component {
     state = {

--- a/src/components/status/services/database.js
+++ b/src/components/status/services/database.js
@@ -1,0 +1,16 @@
+import {getDbLocks as _getDbLocks, getDbQueries as _getDbQueries} from "../../../services/gob_api";
+import {memoize} from "../../../services/utils";
+
+// Get new data only if last call is more than 1500 msecs ago
+const memoizedLocks = memoize(_getDbLocks, 1500)
+
+export async function getDbLocks() {
+    return memoizedLocks()
+}
+
+// Get new data only if last call is more than 1500 msecs ago
+const memoizedQueries = memoize(_getDbQueries, 1500)
+
+export async function getDbQueries() {
+    return memoizedQueries()
+}

--- a/src/services/gob_api.test.js
+++ b/src/services/gob_api.test.js
@@ -20,7 +20,7 @@ it("should call the GOB API and return the guarded get response for locks", asyn
     expect(locks).toBe(mockGuardedGet)
 })
 
-it("it should call the GOB API and return the guarded get response for queries", async () => {
+it("should call the GOB API and return the guarded get response for queries", async () => {
     const queries = await getDbQueries()
     expect(guardedGet).toHaveBeenCalledWith(`${mockAPI}gob/info/activity`, JSONResponse)
     expect(queries).toBe(mockGuardedGet)

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -1,0 +1,21 @@
+export function memoize(method, msec=Number.MAX_SAFE_INTEGER) {
+    let cache = {}
+
+    return async function() {
+        let args = JSON.stringify(arguments)
+        let now = new Date()
+
+        if (cache[args]) {
+            let age = now.getTime() - cache[args].timestamp.getTime()
+            if (age >= msec) {
+                delete cache[args]
+            }
+        }
+
+        cache[args] = cache[args] || {
+            timestamp: now,
+            result: method.apply(this, arguments)
+        }
+        return cache[args].result
+    }
+}

--- a/src/services/utils.test.js
+++ b/src/services/utils.test.js
@@ -1,0 +1,34 @@
+import MockDate from 'mockdate'
+import {memoize} from "./utils";
+
+it("should memoize method results for a maximum number of seconds", async () => {
+    let nRealCalls = 0
+
+    function double(n) {
+        nRealCalls++;
+        return 2 * n
+    }
+    let m = memoize(n => double(n), 2000)
+
+    MockDate.set(new Date('2020', 1, 1, 12, 0, 0).toISOString())
+    expect(await m(5)).toBe(10)
+    expect(nRealCalls).toBe(1)
+    await m(5)
+    await m(5)
+    expect(nRealCalls).toBe(1)
+
+    MockDate.set(new Date('2020', 1, 1, 12, 0, 1).toISOString())
+    expect(await m(5)).toBe(10)
+    expect(nRealCalls).toBe(1)
+
+    MockDate.set(new Date('2020', 1, 1, 12, 0, 2).toISOString())
+    expect(await m(5)).toBe(10)
+    expect(nRealCalls).toBe(2)
+
+    MockDate.set(new Date('2020', 1, 1, 12, 0, 30).toISOString())
+    expect(await m(5)).toBe(10)
+    expect(nRealCalls).toBe(3)
+
+    expect(await m(10)).toBe(20)
+    expect(nRealCalls).toBe(4)  // Other arguments!
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -7085,6 +7085,11 @@ mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mockdate@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.2.tgz#a5a7bb5820da617747af424d7a4dcb22c6c03d79"
+  integrity sha512-ldfYSUW1ocqSHGTK6rrODUiqAFPGAg0xaHqYJ5tvj1hQyFsjuHpuWgWFTZWwDVlzougN/s2/mhDr8r5nY5xDpA==
+
 moment-timezone@^0.5.31:
   version "0.5.31"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.31.tgz#9c40d8c5026f0c7ab46eda3d63e49c155148de05"


### PR DESCRIPTION
Add statusicons to jobs for number of running jobs
Prevent click on badges in JobHeader to open job details
Use memoization in status components to limit number of calls to management API
