### PR TITLE
Fix restart dump

### DIFF
--- a/src/services/gob.js
+++ b/src/services/gob.js
@@ -77,6 +77,16 @@ export async function getJob(id) {
   var data = await queryJob(id);
 
   var jobinfos = data.jobinfo;
+  if (jobinfos) {
+    // jobInfo args is a jsonified string
+    jobinfos.forEach(jobInfo => {
+      jobInfo.args = JSON.parse((jobInfo.args || "[]").replace(/'/g, '"'))
+      // export to Database => dump
+      if (jobInfo.type === 'export' && jobInfo.args.includes('Database')) {
+        jobInfo.type = 'dump'
+      }
+    })
+  }
   return jobinfos ? jobinfos[0] : null;
 }
 

--- a/src/services/gob.test.js
+++ b/src/services/gob.test.js
@@ -132,7 +132,9 @@ it("should provide logs", async () => {
 
 it("should provide job", async () => {
     let mockJob = jest.fn(async id => ({
-        jobinfo: id
+        jobinfo: [{
+            id
+        }]
     }))
     jest.mock("../graphql/queries", () => ({
         queryJob: mockJob
@@ -140,12 +142,43 @@ it("should provide job", async () => {
     const { getJob } = require("./gob")
 
     let result = await getJob([1, 2, 3])
-    expect(result).toEqual(1)
+    expect(result).toEqual({"args": [], "id": [1, 2, 3]})
 
     result = await getJob([2, 3])
-    expect(result).toEqual(2)
+    expect(result).toEqual({"args": [], "id": [2, 3]})
 
     result = await getJob(null)
+    expect(result).toEqual({"args": [], "id": null})
+})
+
+it("recognizes dump jobs", async () => {
+    let mockJob = jest.fn(async () => ({
+        jobinfo: [{
+            id: 'any id',
+            args: "['a', 'Database', 'b']",
+            type: "export"
+        }]
+    }))
+    jest.mock("../graphql/queries", () => ({
+        queryJob: mockJob
+    }))
+    const { getJob } = require("./gob")
+
+    let result = await getJob()
+    expect(result).toEqual({
+        args: ["a", "Database", "b"],
+        id: "any id",
+        type: "dump"
+    })
+})
+
+it("handles empty job responses", async () => {
+    jest.mock("../graphql/queries", () => ({
+        queryJob: () => ({data: null})
+    }))
+    const { getJob } = require("./gob")
+
+    let result = await getJob()
     expect(result).toEqual(null)
 })
 

--- a/test.sh
+++ b/test.sh
@@ -9,12 +9,12 @@ node node_modules/eslint/bin/eslint.js --config node_modules/eslint-config-react
 echo "Running unit and coverage tests"
 yarn test --watchAll=false --coverage
 
-#echo "Checking package versions"
-#yarn install -A
-#yarn audit --level high || auditexit=$?
-#
-#if [ $auditexit -ge 8 ]; then
-#  exit $auditexit
-#else
-#  echo "No HIGH or CRITICAL security issues found"
-#fi
+echo "Checking package versions"
+yarn install -A
+yarn audit --level high || auditexit=$?
+
+if [ $auditexit -ge 8 ]; then
+  exit $auditexit
+else
+  echo "No HIGH or CRITICAL security issues found"
+fi


### PR DESCRIPTION
Dump jobs are export jobs with destination Database.
These jobs are recognized during the request and the type is set to dump.