### PR TITLE
URL for public endpoint changed to /public

### DIFF
--- a/src/components/jobs/JobHeader.js
+++ b/src/components/jobs/JobHeader.js
@@ -34,7 +34,7 @@ const JobHeader = props => {
     }
 
     const badges = () => {
-        const dataLink = `${get_gob_api()}gob/dump/qa/${job.catalogue}_${job.entity}?format=csv`;
+        const dataLink = `${get_gob_api()}gob/public/dump/qa/${job.catalogue}_${job.entity}?format=csv`;
 
         const levels = {
             infos: {},


### PR DESCRIPTION
To be able to dump qa records to csv the public link to the dump API is required.